### PR TITLE
Support Custom VMs

### DIFF
--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -102,11 +102,9 @@ def _graal_binary_implementation(ctx):
 
     if ctx.attr.reflection_configuration != None:
         args.add("-H:ReflectionConfigurationFiles={path}".format(path=ctx.file.reflection_configuration.path))
-        classpath_depset = [ctx.file.reflection_configuration]
-        classpath_transitive = [classpath_depset]
+        input_depset = depset([ctx.file.reflection_configuration] + configsets, transitive=[classpath_depset])
     else:
-        classpath_depset = []
-        classpath_transitive = []
+        input_depset = depset(configsets, transitive=[])
 
     if ctx.attr.debug:
         args.add("-H:+ReportExceptionStackTraces")
@@ -116,7 +114,7 @@ def _graal_binary_implementation(ctx):
             args.add(arg)
 
     ctx.actions.run(
-        inputs = depset(classpath_depset + configsets, transitive=classpath_transitive),
+        inputs = input_depset,
         outputs = [ctx.outputs.bin],
         arguments = [args],
         executable = graal,

--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -102,7 +102,7 @@ def _graal_binary_implementation(ctx):
 
     if ctx.attr.reflection_configuration != None:
         args.add("-H:ReflectionConfigurationFiles={path}".format(path=ctx.file.reflection_configuration.path))
-        input_depset = depset([ctx.file.reflection_configuration] + configsets, transitive=classpath_depset)
+        input_depset = depset([ctx.file.reflection_configuration] + configsets, transitive=[classpath_depset])
     else:
         input_depset = depset(configsets)
 

--- a/graal/graal.bzl
+++ b/graal/graal.bzl
@@ -102,9 +102,9 @@ def _graal_binary_implementation(ctx):
 
     if ctx.attr.reflection_configuration != None:
         args.add("-H:ReflectionConfigurationFiles={path}".format(path=ctx.file.reflection_configuration.path))
-        input_depset = depset([ctx.file.reflection_configuration] + configsets, transitive=[classpath_depset])
+        input_depset = depset([ctx.file.reflection_configuration] + configsets, transitive=classpath_depset)
     else:
-        input_depset = depset(configsets, transitive=[])
+        input_depset = depset(configsets)
 
     if ctx.attr.debug:
         args.add("-H:+ReportExceptionStackTraces")

--- a/graal/graal_bindist.bzl
+++ b/graal/graal_bindist.bzl
@@ -5,22 +5,22 @@ _graal_archive_internal_prefixs = {
 
 _graal_version_configs = {
     "19.0.0": {
-        "urls": ["https://github.com/oracle/graal/releases/download/vm-{version}/graalvm-ce-{platform}-{version}.tar.gz"],
+        "url_template": "https://github.com/oracle/graal/releases/download/vm-{version}/graalvm-{edition}-{platform}-{version}.tar.gz",
         "sha": {
-            "8": {
+            "8-ce": {
                 "darwin-amd64": "fc652566e61b9b774c120da1aea0ae3e28f198d55a297524dcc97b9a83525a79",
                 "linux-amd64": "7ad124cdb19cbaa962f6d2f26d1e3eccfeb93afabbf8e81cb65976519f15730c",
             },
         },
     },
     "19.3.1": {
-        "urls": ["https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-{version}/graalvm-ce-java{java_version}-{platform}-{version}.tar.gz"],
+        "url_template": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-{version}/graalvm-{edition}-java{java_version}-{platform}-{version}.tar.gz",
         "sha": {
-            "8": {
+            "8-ce": {
                 "darwin-amd64": "eba3765174f0279ae2dc57c84fc0eb324da778dbfdcc03c6fa8381fe3728aef9",
                 "linux-amd64": "815385a1c35a1db54b9b9622059c9e8e5155460f65c3d713e55d3a84222c9194",
             },
-            "11": {
+            "11-ce": {
                 "darwin-amd64": "b3ea6cf6545332f667b2cc742bbff9949d47e49eecea06334d14f0b69aa1a3f3",
                 "linux-amd64": "691f0577c75c4ba0fb50916087925e6eb8a5a73de51994a37eee022d1e2c9e7d",
             },
@@ -30,7 +30,7 @@ _graal_version_configs = {
 
 _graal_native_image_version_configs = {
     "19.0.0": {
-        "urls": ["https://github.com/oracle/graal/releases/download/vm-{version}/native-image-installable-svm-{platform}-{version}.jar"],
+        "url_template": "https://github.com/oracle/graal/releases/download/vm-{version}/native-image-installable-svm-{platform}-{version}.jar",
         "sha": {
             "8": {
                 "darwin-amd64": "4fa035b31cfd3d86d464e9a67b652c69a0cceb88c6b2f2ce629c55ca2113c786",
@@ -39,7 +39,7 @@ _graal_native_image_version_configs = {
         },
     },
     "19.3.1": {
-        "urls": ["https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-{version}/native-image-installable-svm-java{java_version}-{platform}-{version}.jar"],
+        "url_template": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-{version}/native-image-installable-svm-java{java_version}-{platform}-{version}.jar",
         "sha": {
             "8": {
                 "darwin-amd64": "266d295456dfc588fae52ef2c26cd7e745e6fa0681271e677cad2dd9a1b09461",
@@ -65,16 +65,37 @@ def _graal_bindist_repository_impl(ctx):
     platform = _get_platform(ctx)
     version = ctx.attr.version
     java_version = ctx.attr.java_version
+    edition = ctx.attr.edition
+    url_template_override = ctx.attr.url_template
+    fingerprint_overrides = ctx.attr.fingerprints
     format_args = {
         "version": version,
         "platform": platform,
         "java_version": java_version,
+        "edition": edition,
     }
 
     #Download graal
     config = _graal_version_configs[version]
-    sha = config["sha"][java_version][platform]
-    urls = [url.format(**format_args) for url in config["urls"]]
+    if edition == "ce":
+      if fingerprint_overrides == None:
+        sha = config["sha"]["%s-ce" % java_version][platform]
+      else:
+        sha = fingerprint_overrides[java_version][platform]
+      if url_template_override == None:
+        urls = [config["url_template"].format(**format_args)]
+      else:
+        urls = [url_template_override.format(**format_args)]
+    elif edition == "ee":
+      if fingerprint_overrides == None:
+        fail("Must provide fingerprint overrides when using GraalVM EE. Use the `fingerprints={}` arg, " +
+             "with keys denoting the Java version ('8', for example).")
+      elif url_template_override == None:
+        fail("Must provide a custom URL download template for use with GraalVM EE. You can use the format " +
+             "variables `version` (GraalVM version), `platform` (OS), `java_version`, and `edition`.")
+      sha = fingerprint_overrides[java_version][platform]
+      urls = [url_template_override.format(**format_args)]
+
     archive_internal_prefix = _graal_archive_internal_prefixs[platform].format(**format_args)
 
     ctx.download_and_extract(
@@ -105,6 +126,9 @@ graal_bindist_repository = repository_rule(
     attrs = {
         "version": attr.string(mandatory = True),
         "java_version": attr.string(mandatory = True),
+        "edition": attr.string(mandatory = False, default="ce"),
+        "url_template": attr.string(mandatory = False),
+        "fingerprints": attr.string_dict(mandatory = False),
     },
     implementation = _graal_bindist_repository_impl,
 )

--- a/graal/graal_bindist.bzl
+++ b/graal/graal_bindist.bzl
@@ -25,6 +25,20 @@ _graal_version_configs = {
                 "linux-amd64": "691f0577c75c4ba0fb50916087925e6eb8a5a73de51994a37eee022d1e2c9e7d",
             },
         },
+    },
+    "20.0.0": {
+        "url_template": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-{version}/graalvm-{edition}-java{java_version}-{platform}-{version}.tar.gz",
+        "sha": {
+            "8-ce": {
+                "darwin-amd64": "e3d35fdfe4f62022c42029c052f2b8277b3d896496cf45c2e82d251f5d49701a",
+                "linux-amd64": "16ef8d89f014b4d295b7ca0c54343eab3c7d24e18b2d376665f5b12bb643723d",
+            },
+            "11-ce": {
+                "darwin-amd64": "8ba1205bb08cab04f1efc72423674d5816efbc3b22e482709c508788d87a692a",
+                "linux-aarch64": "dd230410722d3a7ac25c1318adccddec3f5d85af92aef5906a8e2d755bb2168a",
+                "linux-amd64": "d16c4a340a4619d98936754caeb6f49ee7a61d809c5a270e192b91cbc474c726",
+            },
+        },
     }
 }
 
@@ -48,6 +62,20 @@ _graal_native_image_version_configs = {
             "11": {
                 "darwin-amd64": "6bd2bace9773a2ac7ff8182a36f84507678e71f94bf3f0c4646a091100644e13",
                 "linux-amd64": "fef2e2c71a5408855026e022ae15fda50cb52769aa7d0ec008837f49196ee16a",
+            },
+        },
+    },
+    "20.0.0": {
+        "url_template": "https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-{version}/native-image-installable-svm-java{java_version}-{platform}-{version}.jar",
+        "sha": {
+            "8": {
+                "darwin-amd64": "e42f59bc774b06ebbd8f7defe4460ac5a84aa20d60676f900c7e83b22ef3d4a5",
+                "linux-amd64": "9aee17470ce750eb2454625988c59de86a79b14b811e78085553385bfa7adaff",
+            },
+            "11": {
+                "darwin-amd64": "f7b53adde9c92fe1fac120eb45bb2fe9aab4000bfd9073673d62bcd6b40999af",
+                "linux-amd64": "5e110d42a818b14324779b1d3e6ecfc50065ab9cd90e2e6905be5f922500d8c3",
+                "linux-aarch64": "a796fcfdf8b01ff1eaf74d5603182b548f39bca0e4c54ca1682db8a2fcc338b7",
             },
         },
     }

--- a/graal/graal_bindist.bzl
+++ b/graal/graal_bindist.bzl
@@ -78,11 +78,11 @@ def _graal_bindist_repository_impl(ctx):
     #Download graal
     config = _graal_version_configs[version]
     if edition == "ce":
-      if fingerprint_overrides == None:
+      if fingerprint_overrides == None or len(fingerprint_overrides) == 0:
         sha = config["sha"]["%s-ce" % java_version][platform]
       else:
         sha = fingerprint_overrides[java_version][platform]
-      if url_template_override == None:
+      if url_template_override == "DEFAULT":
         urls = [config["url_template"].format(**format_args)]
       else:
         urls = [url_template_override.format(**format_args)]
@@ -107,7 +107,7 @@ def _graal_bindist_repository_impl(ctx):
     # download native image
     native_image_config = _graal_native_image_version_configs[version]
     native_image_sha = native_image_config["sha"][java_version][platform]
-    native_image_urls = [url.format(**format_args) for url in native_image_config["urls"]]
+    native_image_urls = native_image_config["url_template"].format(**format_args)
 
     ctx.download(
         url = native_image_urls,
@@ -127,7 +127,7 @@ graal_bindist_repository = repository_rule(
         "version": attr.string(mandatory = True),
         "java_version": attr.string(mandatory = True),
         "edition": attr.string(mandatory = False, default="ce"),
-        "url_template": attr.string(mandatory = False),
+        "url_template": attr.string(mandatory = False, default="DEFAULT"),
         "fingerprints": attr.string_dict(mandatory = False),
     },
     implementation = _graal_bindist_repository_impl,


### PR DESCRIPTION
This changeset supports use of custom Graal VMs, by way of (1) a custom download URL template, and (2) custom fingerprints for the downloaded VM binary. This allows someone to invoke the `graal_bindist_repository` with the following pattern to use a custom VM:

```python
graal_bindist_repository(
  version = "19.3.1",
  java_version = "8",
  edition = "ce",
  url_template = "https://my-internal-server.local/graalvm-{platform}-{version}-{java_version}.tar.gz",
  fingerprints = {
    "8": {
        "darwin-amd64": "<some-sha-here>",
        "linux-amd64": "<some-sha-here>",
    },
    "11": {
        "darwin-amd64": "<some-sha-here>",
        "linux-amd64": "<some-sha-here>",
    },
  },
)
```

This will use the URL template, and hashes, in the invocation rather than using the defaults.